### PR TITLE
feat: add Windows Task Scheduler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run AI agents on a schedule. Set up recurring tasks that execute autonomously—
 Schedule a daily job at 9am to search Facebook Marketplace for posters under $100 and send the top 5 deals to my Telegram
 ```
 
-This is an [OpenCode](https://opencode.ai) plugin that uses your OS's native scheduler (launchd on Mac, systemd on Linux) to run prompts reliably—survives reboots, catches up on missed runs.
+This is an [OpenCode](https://opencode.ai) plugin that uses your OS's native scheduler (launchd on macOS, systemd on Linux, Task Scheduler on Windows) to run prompts reliably.
 
 As of `v1.2.0`, jobs are scoped by `workdir` (so different projects don't collide), and scheduled runs are supervised (no overlap + optional timeout).
 
@@ -68,6 +68,20 @@ Jobs run from the working directory where you created them, picking up your `ope
 - **Non-interactive by default**: scheduled runs force `OPENCODE_PERMISSION` to deny "question" prompts, so jobs don't hang waiting for approvals.
 - **Optional timeout**: set `timeoutSeconds` to hard-stop long runs (SIGTERM, then SIGKILL).
 
+### Platform Support
+
+| Platform | Scheduler backend | Notes |
+|------|------|------|
+| macOS | `launchd` | Full support (supervised scheduled runs) |
+| Linux | `systemd --user` | Full support (supervised scheduled runs) |
+| Windows | `schtasks` (Task Scheduler) | Supported with cron subset mapping (see limits below) |
+
+Windows Task Scheduler limits:
+
+- Cron expressions that use unsupported combinations (for example, month + weekday constraints, or month-only without explicit day-of-month) return a clear error with guidance.
+- Complex cron schedules may be expanded into multiple Windows tasks under `\\OpenCode\\opencode-job-...`.
+- Windows scheduled runs currently do **not** use the supervisor pipeline used on macOS/Linux, so no-overlap and timeout enforcement are not guaranteed by the OS integration itself.
+
 ---
 
 ## Reference
@@ -123,6 +137,7 @@ Tools accept an optional `format: "json"` argument to return structured output w
 | Supervisor script | `~/.config/opencode/scheduler/supervisor.pl` |
 | launchd plists (Mac) | `~/Library/LaunchAgents/com.opencode.job.<scopeId>.*.plist` |
 | systemd units (Linux) | `~/.config/systemd/user/opencode-job-<scopeId>-*.{service,timer}` |
+| Task Scheduler entries (Windows) | `\\OpenCode\\opencode-job-<scopeId>-*` |
 
 Legacy note: older versions stored jobs in `~/.config/opencode/jobs/*.json` and used unscoped unit names. `delete_job` removes both scoped and legacy artifacts.
 
@@ -181,6 +196,7 @@ Then add `@scheduled-job-best-practices` at the top of scheduled job prompts.
 1. Check if installed:
    - Mac: `launchctl list | grep opencode`
    - Linux: `systemctl --user list-timers | grep opencode`
+   - Windows: `schtasks /Query /TN "\\OpenCode\\opencode-job-*"`
 
 2. Check logs: `Show logs for my-job`
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,13 +1,13 @@
 /**
  * OpenCode Scheduler Plugin
  *
- * Schedule recurring jobs using launchd (Mac) or systemd (Linux).
+ * Schedule recurring jobs using launchd (Mac), systemd (Linux), or schtasks (Windows).
  * Jobs are stored under ~/.config/opencode/scheduler/ (scoped by workdir).
  *
  * Features:
  * - Survives reboots
  * - Catches up on missed runs (if computer was asleep)
- * - Cross-platform (Mac + Linux)
+ * - Cross-platform (Mac + Linux + Windows)
  * - Working directory support for MCP configs
  * - Environment variable injection (PATH for node/npx)
  */

--- a/dist/index.js
+++ b/dist/index.js
@@ -12345,9 +12345,12 @@ var SUPERVISOR_PATH = join(SCHEDULER_DIR, "supervisor.pl");
 var SCHEDULER_CONFIG = join(OPENCODE_CONFIG, "opencode-scheduler.json");
 var IS_MAC = platform() === "darwin";
 var IS_LINUX = platform() === "linux";
+var IS_WINDOWS = platform() === "win32";
 var LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents");
 var LAUNCHD_PREFIX = "com.opencode.job";
 var SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user");
+var WINDOWS_TASK_ROOT = "\\OpenCode";
+var WINDOWS_TASK_PREFIX = "opencode-job";
 function ensureDir(dir) {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -12994,6 +12997,132 @@ function cronToSystemdCalendars(cron) {
   }
   return calendars;
 }
+var WINDOWS_WEEKDAYS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+var WINDOWS_MONTHS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+function pad2(value) {
+  return value.toString().padStart(2, "0");
+}
+function formatStartTime(hour, minute) {
+  return `${pad2(hour)}:${pad2(minute)}`;
+}
+function windowsTaskBaseName(job) {
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir());
+  return `${WINDOWS_TASK_PREFIX}-${scopeId}-${job.slug}`;
+}
+function windowsTaskName(baseName, index, total) {
+  const suffix = total > 1 ? `-${index + 1}` : "";
+  return `${WINDOWS_TASK_ROOT}\\${baseName}${suffix}`;
+}
+function quoteWindowsArg(value) {
+  if (!/[\s"]/u.test(value))
+    return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+function getWindowsInvocation(job) {
+  const invocation = job.invocation ?? buildOpencodeArgs(job);
+  return invocation;
+}
+function buildWindowsTaskCommand(job) {
+  const invocation = getWindowsInvocation(job);
+  return [invocation.command, ...invocation.args].map((arg) => quoteWindowsArg(arg)).join(" ");
+}
+function maybeStep(field) {
+  const match = field.match(/^\*\/(\d+)$/);
+  if (!match)
+    return null;
+  const step = parseInt(match[1], 10);
+  return Number.isFinite(step) && step > 0 ? step : null;
+}
+function ensureWindowsRepresentable(cron) {
+  const [minuteField, hourField, dayField, monthField, weekdayField] = splitCronExpression(cron);
+  const minuteStep = maybeStep(minuteField);
+  const hourStep = maybeStep(hourField);
+  if (minuteField === "*" && hourField === "*" && dayField === "*" && monthField === "*" && weekdayField === "*") {
+    return [{ schedule: "MINUTE", modifier: "1", startTime: "00:00" }];
+  }
+  if (minuteStep !== null && hourField === "*" && dayField === "*" && monthField === "*" && weekdayField === "*") {
+    if (minuteStep > 1439) {
+      throw new Error(`Windows Task Scheduler supports at most every 1439 minutes. Use ${minuteStep} with a smaller value or switch to an hourly/daily cron.`);
+    }
+    return [{ schedule: "MINUTE", modifier: String(minuteStep), startTime: "00:00" }];
+  }
+  const minuteValues = parseCronField(minuteField, 0, 59, "minute");
+  const hourValues = parseCronField(hourField, 0, 23, "hour");
+  const dayValues = parseCronField(dayField, 1, 31, "day of month");
+  const monthValues = parseCronField(monthField, 1, 12, "month");
+  const weekdayValues = parseCronField(weekdayField, 0, 7, "day of week", true);
+  if (hourStep !== null && minuteValues && minuteValues.length === 1 && dayField === "*" && monthField === "*" && weekdayField === "*") {
+    return [{ schedule: "HOURLY", modifier: String(hourStep), startTime: formatStartTime(0, minuteValues[0]) }];
+  }
+  if (!minuteValues || minuteValues.length === 0 || !hourValues || hourValues.length === 0) {
+    throw new Error("Windows Task Scheduler requires explicit minute and hour values for this cron expression. Use formats like '0 9 * * *', '30 8 * * 1', '*/15 * * * *', or '0 */6 * * *'.");
+  }
+  if (monthValues && weekdayValues) {
+    throw new Error("Windows Task Scheduler cannot combine specific months with day-of-week constraints in cron. Split this into multiple jobs (for example: one monthly job and one weekly job).");
+  }
+  if (monthValues && !dayValues) {
+    throw new Error("Windows Task Scheduler cannot represent 'every day in selected months'. Use explicit day-of-month values (for example '0 9 1,15 1,7 *') or create separate jobs.");
+  }
+  const plans = [];
+  for (const minute of minuteValues) {
+    for (const hour of hourValues) {
+      const startTime = formatStartTime(hour, minute);
+      if (dayValues && weekdayValues) {
+        plans.push({
+          schedule: "MONTHLY",
+          days: dayValues.join(","),
+          months: monthValues ? monthValues.map((value) => WINDOWS_MONTHS[value - 1]).join(",") : undefined,
+          startTime
+        });
+        plans.push({
+          schedule: "WEEKLY",
+          weekdays: weekdayValues.map((value) => WINDOWS_WEEKDAYS[value]).join(","),
+          startTime
+        });
+      } else if (weekdayValues) {
+        plans.push({
+          schedule: "WEEKLY",
+          weekdays: weekdayValues.map((value) => WINDOWS_WEEKDAYS[value]).join(","),
+          startTime
+        });
+      } else if (dayValues) {
+        plans.push({
+          schedule: "MONTHLY",
+          days: dayValues.join(","),
+          months: monthValues ? monthValues.map((value) => WINDOWS_MONTHS[value - 1]).join(",") : undefined,
+          startTime
+        });
+      } else if (monthValues) {
+        throw new Error("Windows Task Scheduler cannot represent month-only cron constraints without day-of-month. Use explicit days or create separate jobs.");
+      } else {
+        plans.push({ schedule: "DAILY", startTime });
+      }
+    }
+  }
+  return plans;
+}
+function cronToWindowsTaskDefinitions(job) {
+  const plans = ensureWindowsRepresentable(job.schedule);
+  const baseName = windowsTaskBaseName(job);
+  const command = buildWindowsTaskCommand(job);
+  return plans.map((plan, index) => {
+    const args = ["/Create", "/F", "/TN", windowsTaskName(baseName, index, plans.length), "/TR", command, "/SC", plan.schedule];
+    if (plan.modifier) {
+      args.push("/MO", plan.modifier);
+    }
+    if (plan.weekdays) {
+      args.push("/D", plan.weekdays);
+    }
+    if (plan.days) {
+      args.push("/D", plan.days);
+    }
+    if (plan.months) {
+      args.push("/M", plan.months);
+    }
+    args.push("/ST", plan.startTime);
+    return { name: windowsTaskName(baseName, index, plans.length), args };
+  });
+}
 function createLaunchdPlist(job) {
   const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir());
   const label = `${LAUNCHD_PREFIX}.${scopeId}.${job.slug}`;
@@ -13170,13 +13299,37 @@ function uninstallSystemdJob(job) {
     execSync("systemctl --user daemon-reload", { stdio: "ignore" });
   } catch {}
 }
+function installWindowsJob(job) {
+  uninstallWindowsJob(job);
+  const taskDefinitions = cronToWindowsTaskDefinitions(job);
+  for (const task of taskDefinitions) {
+    execFileSync("schtasks", task.args, { stdio: "ignore" });
+  }
+}
+function uninstallWindowsJob(job) {
+  const candidates = new Set;
+  const scopedBase = windowsTaskBaseName(job);
+  const legacyBase = `${WINDOWS_TASK_PREFIX}-${job.slug}`;
+  for (let i = 0;i < 64; i += 1) {
+    const suffix = i === 0 ? "" : `-${i + 1}`;
+    candidates.add(`${WINDOWS_TASK_ROOT}\\${scopedBase}${suffix}`);
+    candidates.add(`${WINDOWS_TASK_ROOT}\\${legacyBase}${suffix}`);
+  }
+  for (const taskName of candidates) {
+    try {
+      execFileSync("schtasks", ["/Delete", "/TN", taskName, "/F"], { stdio: "ignore" });
+    } catch {}
+  }
+}
 function installJob(job) {
   if (IS_MAC) {
     installLaunchdJob(job);
   } else if (IS_LINUX) {
     installSystemdJob(job);
+  } else if (IS_WINDOWS) {
+    installWindowsJob(job);
   } else {
-    throw new Error(`Unsupported platform: ${platform()}. Only macOS and Linux are supported.`);
+    throw new Error(`Unsupported platform: ${platform()}. Supported platforms: macOS, Linux, and Windows.`);
   }
 }
 function uninstallJob(job) {
@@ -13184,6 +13337,8 @@ function uninstallJob(job) {
     uninstallLaunchdJob(job);
   } else if (IS_LINUX) {
     uninstallSystemdJob(job);
+  } else if (IS_WINDOWS) {
+    uninstallWindowsJob(job);
   }
 }
 function ensureScopeStorage(scopeId) {
@@ -13896,7 +14051,7 @@ var SchedulerPlugin = async () => {
   return {
     tool: {
       schedule_job: tool({
-        description: "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac) or systemd (Linux) for reliable scheduling that survives reboots and catches up on missed runs.",
+        description: "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac), systemd (Linux), or Windows Task Scheduler.",
         args: {
           name: tool.schema.string().describe("A short name for the job (e.g. 'standing desk search')"),
           schedule: tool.schema.string().describe("Cron expression: '0 9 * * *' (daily 9am), '0 */6 * * *' (every 6h), '30 8 * * 1' (Monday 8:30am)"),
@@ -14002,7 +14157,8 @@ var SchedulerPlugin = async () => {
           try {
             saveJob(job);
             installJob(job);
-            const platformName = IS_MAC ? "launchd" : IS_LINUX ? "systemd" : "unknown";
+            const platformName = IS_MAC ? "launchd" : IS_LINUX ? "systemd" : IS_WINDOWS ? "schtasks" : "unknown";
+            const reliabilityLine = IS_WINDOWS ? "Windows note: scheduled runs use Task Scheduler directly. For advanced reliability guarantees, prefer simple cron schedules or split complex jobs." : "The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes.";
             const primaryLine = run.command ? `Command: ${run.command}${run.arguments ? ` ${run.arguments}` : ""}` : `Prompt: ${(run.prompt ?? "").slice(0, 100)}${(run.prompt ?? "").length > 100 ? "..." : ""}`;
             const attachLine = run.attachUrl ? `Attach URL: ${run.attachUrl}
 ` : "";
@@ -14013,7 +14169,7 @@ Platform: ${platformName}
 Working Directory: ${workdir}
 ${attachLine}${primaryLine}
 
-The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes.
+${reliabilityLine}
 
 Commands:
 - "run ${args.name} now" - run immediately

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 /**
  * OpenCode Scheduler Plugin
  *
- * Schedule recurring jobs using launchd (Mac) or systemd (Linux).
+ * Schedule recurring jobs using launchd (Mac), systemd (Linux), or schtasks (Windows).
  * Jobs are stored under ~/.config/opencode/scheduler/ (scoped by workdir).
  *
  * Features:
  * - Survives reboots
  * - Catches up on missed runs (if computer was asleep)
- * - Cross-platform (Mac + Linux)
+ * - Cross-platform (Mac + Linux + Windows)
  * - Working directory support for MCP configs
  * - Environment variable injection (PATH for node/npx)
  */
@@ -31,6 +31,7 @@ const SCHEDULER_CONFIG = join(OPENCODE_CONFIG, "opencode-scheduler.json")
 // Platform detection
 const IS_MAC = platform() === "darwin"
 const IS_LINUX = platform() === "linux"
+const IS_WINDOWS = platform() === "win32"
 
 // launchd paths (Mac)
 const LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents")
@@ -38,6 +39,10 @@ const LAUNCHD_PREFIX = "com.opencode.job"
 
 // systemd paths (Linux)
 const SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user")
+
+// Windows Task Scheduler
+const WINDOWS_TASK_ROOT = "\\OpenCode"
+const WINDOWS_TASK_PREFIX = "opencode-job"
 
 // Ensure directory exists
 function ensureDir(dir: string) {
@@ -848,6 +853,182 @@ function cronToSystemdCalendars(cron: string): string[] {
   return calendars
 }
 
+const WINDOWS_WEEKDAYS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+const WINDOWS_MONTHS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]
+
+interface WindowsTaskDefinition {
+  name: string
+  args: string[]
+}
+
+interface WindowsCronPlan {
+  schedule: "MINUTE" | "HOURLY" | "DAILY" | "WEEKLY" | "MONTHLY"
+  modifier?: string
+  weekdays?: string
+  days?: string
+  months?: string
+  startTime: string
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0")
+}
+
+function formatStartTime(hour: number, minute: number): string {
+  return `${pad2(hour)}:${pad2(minute)}`
+}
+
+function windowsTaskBaseName(job: Job): string {
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir())
+  return `${WINDOWS_TASK_PREFIX}-${scopeId}-${job.slug}`
+}
+
+function windowsTaskName(baseName: string, index: number, total: number): string {
+  const suffix = total > 1 ? `-${index + 1}` : ""
+  return `${WINDOWS_TASK_ROOT}\\${baseName}${suffix}`
+}
+
+function quoteWindowsArg(value: string): string {
+  if (!/[\s"]/u.test(value)) return value
+  return `"${value.replace(/"/g, '""')}"`
+}
+
+function getWindowsInvocation(job: Job): JobInvocation {
+  const invocation = job.invocation ?? buildOpencodeArgs(job)
+  return invocation
+}
+
+function buildWindowsTaskCommand(job: Job): string {
+  const invocation = getWindowsInvocation(job)
+  return [invocation.command, ...invocation.args].map((arg) => quoteWindowsArg(arg)).join(" ")
+}
+
+function maybeStep(field: string): number | null {
+  const match = field.match(/^\*\/(\d+)$/)
+  if (!match) return null
+  const step = parseInt(match[1], 10)
+  return Number.isFinite(step) && step > 0 ? step : null
+}
+
+function ensureWindowsRepresentable(cron: string): WindowsCronPlan[] {
+  const [minuteField, hourField, dayField, monthField, weekdayField] = splitCronExpression(cron)
+
+  const minuteStep = maybeStep(minuteField)
+  const hourStep = maybeStep(hourField)
+
+  if (minuteField === "*" && hourField === "*" && dayField === "*" && monthField === "*" && weekdayField === "*") {
+    return [{ schedule: "MINUTE", modifier: "1", startTime: "00:00" }]
+  }
+
+  if (minuteStep !== null && hourField === "*" && dayField === "*" && monthField === "*" && weekdayField === "*") {
+    if (minuteStep > 1439) {
+      throw new Error(
+        `Windows Task Scheduler supports at most every 1439 minutes. Use ${minuteStep} with a smaller value or switch to an hourly/daily cron.`
+      )
+    }
+    return [{ schedule: "MINUTE", modifier: String(minuteStep), startTime: "00:00" }]
+  }
+
+  const minuteValues = parseCronField(minuteField, 0, 59, "minute")
+  const hourValues = parseCronField(hourField, 0, 23, "hour")
+  const dayValues = parseCronField(dayField, 1, 31, "day of month")
+  const monthValues = parseCronField(monthField, 1, 12, "month")
+  const weekdayValues = parseCronField(weekdayField, 0, 7, "day of week", true)
+
+  if (hourStep !== null && minuteValues && minuteValues.length === 1 && dayField === "*" && monthField === "*" && weekdayField === "*") {
+    return [{ schedule: "HOURLY", modifier: String(hourStep), startTime: formatStartTime(0, minuteValues[0]) }]
+  }
+
+  if (!minuteValues || minuteValues.length === 0 || !hourValues || hourValues.length === 0) {
+    throw new Error(
+      "Windows Task Scheduler requires explicit minute and hour values for this cron expression. Use formats like '0 9 * * *', '30 8 * * 1', '*/15 * * * *', or '0 */6 * * *'."
+    )
+  }
+
+  if (monthValues && weekdayValues) {
+    throw new Error(
+      "Windows Task Scheduler cannot combine specific months with day-of-week constraints in cron. Split this into multiple jobs (for example: one monthly job and one weekly job)."
+    )
+  }
+
+  if (monthValues && !dayValues) {
+    throw new Error(
+      "Windows Task Scheduler cannot represent 'every day in selected months'. Use explicit day-of-month values (for example '0 9 1,15 1,7 *') or create separate jobs."
+    )
+  }
+
+  const plans: WindowsCronPlan[] = []
+  for (const minute of minuteValues) {
+    for (const hour of hourValues) {
+      const startTime = formatStartTime(hour, minute)
+
+      if (dayValues && weekdayValues) {
+        plans.push({
+          schedule: "MONTHLY",
+          days: dayValues.join(","),
+          months: monthValues ? monthValues.map((value) => WINDOWS_MONTHS[value - 1]).join(",") : undefined,
+          startTime,
+        })
+        plans.push({
+          schedule: "WEEKLY",
+          weekdays: weekdayValues.map((value) => WINDOWS_WEEKDAYS[value]).join(","),
+          startTime,
+        })
+      } else if (weekdayValues) {
+        plans.push({
+          schedule: "WEEKLY",
+          weekdays: weekdayValues.map((value) => WINDOWS_WEEKDAYS[value]).join(","),
+          startTime,
+        })
+      } else if (dayValues) {
+        plans.push({
+          schedule: "MONTHLY",
+          days: dayValues.join(","),
+          months: monthValues ? monthValues.map((value) => WINDOWS_MONTHS[value - 1]).join(",") : undefined,
+          startTime,
+        })
+      } else if (monthValues) {
+        throw new Error(
+          "Windows Task Scheduler cannot represent month-only cron constraints without day-of-month. Use explicit days or create separate jobs."
+        )
+      } else {
+        plans.push({ schedule: "DAILY", startTime })
+      }
+    }
+  }
+
+  return plans
+}
+
+function cronToWindowsTaskDefinitions(job: Job): WindowsTaskDefinition[] {
+  const plans = ensureWindowsRepresentable(job.schedule)
+  const baseName = windowsTaskBaseName(job)
+  const command = buildWindowsTaskCommand(job)
+
+  return plans.map((plan, index) => {
+    const args = ["/Create", "/F", "/TN", windowsTaskName(baseName, index, plans.length), "/TR", command, "/SC", plan.schedule]
+
+    if (plan.modifier) {
+      args.push("/MO", plan.modifier)
+    }
+
+    if (plan.weekdays) {
+      args.push("/D", plan.weekdays)
+    }
+
+    if (plan.days) {
+      args.push("/D", plan.days)
+    }
+
+    if (plan.months) {
+      args.push("/M", plan.months)
+    }
+
+    args.push("/ST", plan.startTime)
+    return { name: windowsTaskName(baseName, index, plans.length), args }
+  })
+}
+
 // === LAUNCHD (Mac) ===
 
 function createLaunchdPlist(job: Job): string {
@@ -1067,6 +1248,36 @@ function uninstallSystemdJob(job: Job): void {
   } catch {}
 }
 
+// === WINDOWS TASK SCHEDULER ===
+
+function installWindowsJob(job: Job): void {
+  // Remove stale task variants before (re)creating current definitions.
+  uninstallWindowsJob(job)
+
+  const taskDefinitions = cronToWindowsTaskDefinitions(job)
+  for (const task of taskDefinitions) {
+    execFileSync("schtasks", task.args, { stdio: "ignore" })
+  }
+}
+
+function uninstallWindowsJob(job: Job): void {
+  const candidates = new Set<string>()
+  const scopedBase = windowsTaskBaseName(job)
+  const legacyBase = `${WINDOWS_TASK_PREFIX}-${job.slug}`
+
+  for (let i = 0; i < 64; i += 1) {
+    const suffix = i === 0 ? "" : `-${i + 1}`
+    candidates.add(`${WINDOWS_TASK_ROOT}\\${scopedBase}${suffix}`)
+    candidates.add(`${WINDOWS_TASK_ROOT}\\${legacyBase}${suffix}`)
+  }
+
+  for (const taskName of candidates) {
+    try {
+      execFileSync("schtasks", ["/Delete", "/TN", taskName, "/F"], { stdio: "ignore" })
+    } catch {}
+  }
+}
+
 // === CROSS-PLATFORM ===
 
 function installJob(job: Job): void {
@@ -1074,8 +1285,10 @@ function installJob(job: Job): void {
     installLaunchdJob(job)
   } else if (IS_LINUX) {
     installSystemdJob(job)
+  } else if (IS_WINDOWS) {
+    installWindowsJob(job)
   } else {
-    throw new Error(`Unsupported platform: ${platform()}. Only macOS and Linux are supported.`)
+    throw new Error(`Unsupported platform: ${platform()}. Supported platforms: macOS, Linux, and Windows.`)
   }
 }
 
@@ -1084,6 +1297,8 @@ function uninstallJob(job: Job): void {
     uninstallLaunchdJob(job)
   } else if (IS_LINUX) {
     uninstallSystemdJob(job)
+  } else if (IS_WINDOWS) {
+    uninstallWindowsJob(job)
   }
 }
 
@@ -1927,8 +2142,8 @@ export const SchedulerPlugin: Plugin = async () => {
   return {
     tool: {
        schedule_job: tool({
-         description:
-           "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac) or systemd (Linux) for reliable scheduling that survives reboots and catches up on missed runs.",
+           description:
+            "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac), systemd (Linux), or Windows Task Scheduler.",
           args: {
            name: tool.schema.string().describe("A short name for the job (e.g. 'standing desk search')"),
            schedule: tool.schema
@@ -2075,10 +2290,13 @@ export const SchedulerPlugin: Plugin = async () => {
              saveJob(job)
              installJob(job)
 
-            const platformName = IS_MAC ? "launchd" : IS_LINUX ? "systemd" : "unknown"
-            const primaryLine = run.command
-              ? `Command: ${run.command}${run.arguments ? ` ${run.arguments}` : ""}`
-              : `Prompt: ${(run.prompt ?? "").slice(0, 100)}${(run.prompt ?? "").length > 100 ? "..." : ""}`
+             const platformName = IS_MAC ? "launchd" : IS_LINUX ? "systemd" : IS_WINDOWS ? "schtasks" : "unknown"
+             const reliabilityLine = IS_WINDOWS
+               ? "Windows note: scheduled runs use Task Scheduler directly. For advanced reliability guarantees, prefer simple cron schedules or split complex jobs."
+               : "The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes."
+             const primaryLine = run.command
+               ? `Command: ${run.command}${run.arguments ? ` ${run.arguments}` : ""}`
+               : `Prompt: ${(run.prompt ?? "").slice(0, 100)}${(run.prompt ?? "").length > 100 ? "..." : ""}`
 
             const attachLine = run.attachUrl ? `Attach URL: ${run.attachUrl}
 ` : ""
@@ -2092,7 +2310,7 @@ Platform: ${platformName}
 Working Directory: ${workdir}
 ${attachLine}${primaryLine}
 
-The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes.
+${reliabilityLine}
 
 Commands:
 - "run ${args.name} now" - run immediately


### PR DESCRIPTION
## Summary
- add Windows `schtasks` install/uninstall integration with deterministic task naming under `\\OpenCode`
- map supported cron expressions to Task Scheduler triggers and return actionable errors for unsupported patterns
- keep macOS (`launchd`) and Linux (`systemd`) behavior unchanged, and document Windows platform limits in README

## Validation
- `bun run build`
- `bun run typecheck`