### PR TITLE
fix: fall back to cron when native schedulers unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run AI agents on a schedule. Set up recurring tasks that execute autonomously—
 Schedule a daily job at 9am to search Facebook Marketplace for posters under $100 and send the top 5 deals to my Telegram
 ```
 
-This is an [OpenCode](https://opencode.ai) plugin that uses your OS's native scheduler (launchd on macOS, systemd on Linux, Task Scheduler on Windows) to run prompts reliably.
+This is an [OpenCode](https://opencode.ai) plugin that uses your OS's native scheduler (launchd on macOS, systemd on Linux, Task Scheduler on Windows), with cron fallback where native backends are unavailable.
 
 As of `v1.2.0`, jobs are scoped by `workdir` (so different projects don't collide), and scheduled runs are supervised (no overlap + optional timeout).
 
@@ -74,7 +74,8 @@ Jobs run from the working directory where you created them, picking up your `ope
 | Platform | Scheduler backend | Notes |
 |------|------|------|
 | macOS | `launchd` | Full support (supervised scheduled runs) |
-| Linux | `systemd --user` | Full support (supervised scheduled runs) |
+| Linux (systemd available) | `systemd --user` | Full support (supervised scheduled runs) |
+| Linux / POSIX (no systemd) | `cron` (`crontab`) | Fallback backend (no missed-run catch-up) |
 | Windows | `schtasks` (Task Scheduler) | Supported with cron subset mapping (see limits below) |
 
 Windows Task Scheduler limits:
@@ -195,7 +196,7 @@ Update the standing-desk job to use attachUrl http://localhost:4096
 
 ## Project Philosophy
 
-- This plugin is intentionally a thin wrapper: it schedules `opencode run` via launchd (Mac) or systemd (Linux).
+- This plugin is intentionally a thin wrapper: it schedules `opencode run` via launchd/systemd/schtasks, with cron fallback when native backends are unavailable.
 - Logs are the source of truth for scheduled runs: `~/.config/opencode/logs/*.log`.
 - Resiliency/reporting roadmap (not implemented): `PRD-resilient-execution.md`.
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * OpenCode Scheduler Plugin
  *
- * Schedule recurring jobs using launchd (Mac), systemd (Linux), or schtasks (Windows).
+ * Schedule recurring jobs using launchd (Mac), systemd (Linux), schtasks (Windows), or cron fallback.
  * Jobs are stored under ~/.config/opencode/scheduler/ (scoped by workdir).
  *
  * Features:

--- a/dist/index.js
+++ b/dist/index.js
@@ -12351,6 +12351,7 @@ var LAUNCHD_PREFIX = "com.opencode.job";
 var SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user");
 var WINDOWS_TASK_ROOT = "\\OpenCode";
 var WINDOWS_TASK_PREFIX = "opencode-job";
+var CRON_MANAGED_PREFIX = "opencode-scheduler";
 function ensureDir(dir) {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -13321,25 +13322,197 @@ function uninstallWindowsJob(job) {
     } catch {}
   }
 }
+function isCommandAvailable(command) {
+  try {
+    execSync(`command -v ${command}`, {
+      stdio: "ignore",
+      env: buildRunEnvironment()
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+function isSystemdUserAvailable() {
+  if (!IS_LINUX)
+    return false;
+  if (!isCommandAvailable("systemctl"))
+    return false;
+  try {
+    execSync("systemctl --user show-environment", {
+      stdio: "ignore",
+      env: buildRunEnvironment()
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+function isCronAvailable() {
+  if (IS_WINDOWS)
+    return false;
+  return isCommandAvailable("crontab");
+}
+function cronBlockId(job) {
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir());
+  return `${scopeId}:${job.slug}`;
+}
+function cronLegacyBlockId(job) {
+  return `legacy:${job.slug}`;
+}
+function cronBlockStart(id) {
+  return `# BEGIN ${CRON_MANAGED_PREFIX} ${id}`;
+}
+function cronBlockEnd(id) {
+  return `# END ${CRON_MANAGED_PREFIX} ${id}`;
+}
+function shellEscapeDoubleQuoted(value) {
+  return value.replace(/(["\\$`])/g, "\\$1");
+}
+function readUserCrontab() {
+  try {
+    return execFileSync("crontab", ["-l"], { encoding: "utf-8" });
+  } catch (error45) {
+    const status = typeof error45 === "object" && error45 !== null ? error45.status : undefined;
+    const stderrValue = typeof error45 === "object" && error45 !== null && "stderr" in error45 ? error45.stderr : undefined;
+    const stderr = Buffer.isBuffer(stderrValue) ? stderrValue.toString("utf-8") : stderrValue ?? "";
+    const noCrontab = status === 1 && (!stderr.trim() || /no crontab/i.test(stderr));
+    if (noCrontab)
+      return "";
+    throw error45;
+  }
+}
+function writeUserCrontab(content) {
+  const normalized = content.trim();
+  const input = normalized ? `${normalized}
+` : "";
+  execFileSync("crontab", ["-"], { input });
+}
+function stripManagedCronBlocks(content, blockIds) {
+  const lines = content ? content.split(/\r?\n/) : [];
+  const retained = [];
+  const prefix = `# BEGIN ${CRON_MANAGED_PREFIX} `;
+  const endPrefix = `# END ${CRON_MANAGED_PREFIX} `;
+  let removed = 0;
+  for (let index = 0;index < lines.length; ) {
+    const line = lines[index];
+    if (!line.startsWith(prefix)) {
+      retained.push(line);
+      index += 1;
+      continue;
+    }
+    const id = line.slice(prefix.length).trim();
+    let endIndex = lines.length - 1;
+    for (let probe = index + 1;probe < lines.length; probe += 1) {
+      if (lines[probe] === `${endPrefix}${id}`) {
+        endIndex = probe;
+        break;
+      }
+    }
+    if (blockIds.has(id)) {
+      removed += 1;
+    } else {
+      for (let keep = index;keep <= endIndex; keep += 1) {
+        retained.push(lines[keep]);
+      }
+    }
+    index = endIndex + 1;
+  }
+  return {
+    content: retained.join(`
+`).replace(/\n{3,}/g, `
+
+`).trimEnd(),
+    removed
+  };
+}
+function createCronEntry(job) {
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir());
+  const jobPath = jobFilePath(scopeId, job.slug);
+  const logFilePath = scopedLogPath(scopeId, job.slug);
+  const escapedSupervisor = shellEscapeDoubleQuoted(SUPERVISOR_PATH);
+  const escapedJobPath = shellEscapeDoubleQuoted(jobPath);
+  const escapedLogPath = shellEscapeDoubleQuoted(logFilePath);
+  const escapedPath = shellEscapeDoubleQuoted(getEnhancedPath());
+  return `${job.schedule} PATH="${escapedPath}" /usr/bin/perl "${escapedSupervisor}" "${escapedJobPath}" >> "${escapedLogPath}" 2>&1`;
+}
+function installCronJob(job) {
+  if (!isCronAvailable()) {
+    throw new Error("cron backend is unavailable: `crontab` command not found.");
+  }
+  ensureDir(LOGS_DIR);
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir());
+  ensureDir(scopeLogsDir(scopeId));
+  ensureSupervisorScript();
+  const blockId = cronBlockId(job);
+  const current = readUserCrontab();
+  const stripped = stripManagedCronBlocks(current, new Set([blockId, cronLegacyBlockId(job)]));
+  const block = [cronBlockStart(blockId), createCronEntry(job), cronBlockEnd(blockId)].join(`
+`);
+  const next = [stripped.content.trim(), block].filter(Boolean).join(`
+
+`);
+  writeUserCrontab(next);
+}
+function uninstallCronJob(job) {
+  if (!isCronAvailable())
+    return;
+  const current = readUserCrontab();
+  const stripped = stripManagedCronBlocks(current, new Set([cronBlockId(job), cronLegacyBlockId(job)]));
+  if (stripped.removed === 0)
+    return;
+  writeUserCrontab(stripped.content);
+}
+function resolveSchedulerBackend() {
+  if (IS_MAC)
+    return "launchd";
+  if (IS_WINDOWS)
+    return "schtasks";
+  if (isSystemdUserAvailable())
+    return "systemd";
+  if (isCronAvailable())
+    return "cron";
+  if (IS_LINUX) {
+    throw new Error("No supported scheduler backend found: systemd --user is unavailable and `crontab` is not installed.");
+  }
+  throw new Error(`Unsupported platform: ${platform()}. Supported platforms: macOS (launchd), Linux (systemd or cron), Windows, and POSIX systems with cron.`);
+}
 function installJob(job) {
-  if (IS_MAC) {
+  const backend = resolveSchedulerBackend();
+  if (backend === "launchd") {
     installLaunchdJob(job);
-  } else if (IS_LINUX) {
-    installSystemdJob(job);
-  } else if (IS_WINDOWS) {
+  } else if (backend === "systemd") {
+    try {
+      installSystemdJob(job);
+    } catch (error45) {
+      if (!isCronAvailable()) {
+        throw error45;
+      }
+      installCronJob(job);
+      return "cron";
+    }
+  } else if (backend === "schtasks") {
     installWindowsJob(job);
   } else {
-    throw new Error(`Unsupported platform: ${platform()}. Supported platforms: macOS, Linux, and Windows.`);
+    installCronJob(job);
   }
+  return backend;
 }
 function uninstallJob(job) {
   if (IS_MAC) {
     uninstallLaunchdJob(job);
-  } else if (IS_LINUX) {
-    uninstallSystemdJob(job);
-  } else if (IS_WINDOWS) {
-    uninstallWindowsJob(job);
+    return;
   }
+  if (IS_WINDOWS) {
+    uninstallWindowsJob(job);
+    return;
+  }
+  if (IS_LINUX) {
+    uninstallSystemdJob(job);
+    uninstallCronJob(job);
+    return;
+  }
+  uninstallCronJob(job);
 }
 function ensureScopeStorage(scopeId) {
   ensureDir(SCHEDULER_DIR);
@@ -14187,7 +14360,7 @@ var SchedulerPlugin = async () => {
   return {
     tool: {
       schedule_job: tool({
-        description: "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac), systemd (Linux), or Windows Task Scheduler.",
+        description: "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac), systemd (Linux), Windows Task Scheduler, or cron fallback when needed.",
         args: {
           name: tool.schema.string().describe("A short name for the job (e.g. 'standing desk search')"),
           schedule: tool.schema.string().describe("Cron expression: '0 9 * * *' (daily 9am), '0 */6 * * *' (every 6h), '30 8 * * 1' (Monday 8:30am)"),
@@ -14292,9 +14465,9 @@ var SchedulerPlugin = async () => {
           }
           try {
             saveJob(job);
-            installJob(job);
-            const platformName = IS_MAC ? "launchd" : IS_LINUX ? "systemd" : IS_WINDOWS ? "schtasks" : "unknown";
-            const reliabilityLine = IS_WINDOWS ? "Windows note: scheduled runs use Task Scheduler directly. For advanced reliability guarantees, prefer simple cron schedules or split complex jobs." : "The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes.";
+            const backend = installJob(job);
+            const platformName = backend;
+            const reliabilityLine = backend === "schtasks" ? "Windows note: scheduled runs use Task Scheduler directly. For advanced reliability guarantees, prefer simple cron schedules or split complex jobs." : backend === "cron" ? "Cron note: missed runs during sleep are not replayed. For catch-up behavior, use launchd or systemd when available." : "The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes.";
             const primaryLine = run.command ? `Command: ${run.command}${run.arguments ? ` ${run.arguments}` : ""}` : `Prompt: ${(run.prompt ?? "").slice(0, 100)}${(run.prompt ?? "").length > 100 ? "..." : ""}`;
             const attachLine = run.attachUrl ? `Attach URL: ${run.attachUrl}
 ` : "";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-scheduler",
   "version": "1.3.0",
-  "description": "OpenCode plugin for scheduling recurring jobs using launchd (Mac) or systemd (Linux)",
+  "description": "OpenCode plugin for scheduling recurring jobs using launchd, systemd, Task Scheduler, or cron fallback",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * OpenCode Scheduler Plugin
  *
- * Schedule recurring jobs using launchd (Mac), systemd (Linux), or schtasks (Windows).
+ * Schedule recurring jobs using launchd (Mac), systemd (Linux), schtasks (Windows), or cron fallback.
  * Jobs are stored under ~/.config/opencode/scheduler/ (scoped by workdir).
  *
  * Features:
@@ -43,6 +43,9 @@ const SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user")
 // Windows Task Scheduler
 const WINDOWS_TASK_ROOT = "\\OpenCode"
 const WINDOWS_TASK_PREFIX = "opencode-job"
+
+// cron backend
+const CRON_MANAGED_PREFIX = "opencode-scheduler"
 
 // Ensure directory exists
 function ensureDir(dir: string) {
@@ -1280,26 +1283,219 @@ function uninstallWindowsJob(job: Job): void {
 
 // === CROSS-PLATFORM ===
 
-function installJob(job: Job): void {
-  if (IS_MAC) {
+type SchedulerBackend = "launchd" | "systemd" | "schtasks" | "cron"
+
+function isCommandAvailable(command: string): boolean {
+  try {
+    execSync(`command -v ${command}`, {
+      stdio: "ignore",
+      env: buildRunEnvironment(),
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isSystemdUserAvailable(): boolean {
+  if (!IS_LINUX) return false
+  if (!isCommandAvailable("systemctl")) return false
+  try {
+    execSync("systemctl --user show-environment", {
+      stdio: "ignore",
+      env: buildRunEnvironment(),
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isCronAvailable(): boolean {
+  if (IS_WINDOWS) return false
+  return isCommandAvailable("crontab")
+}
+
+function cronBlockId(job: Job): string {
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir())
+  return `${scopeId}:${job.slug}`
+}
+
+function cronLegacyBlockId(job: Job): string {
+  return `legacy:${job.slug}`
+}
+
+function cronBlockStart(id: string): string {
+  return `# BEGIN ${CRON_MANAGED_PREFIX} ${id}`
+}
+
+function cronBlockEnd(id: string): string {
+  return `# END ${CRON_MANAGED_PREFIX} ${id}`
+}
+
+function shellEscapeDoubleQuoted(value: string): string {
+  return value.replace(/(["\\$`])/g, "\\$1")
+}
+
+function readUserCrontab(): string {
+  try {
+    return execFileSync("crontab", ["-l"], { encoding: "utf-8" }) as string
+  } catch (error) {
+    const status = typeof error === "object" && error !== null ? (error as { status?: number }).status : undefined
+    const stderrValue =
+      typeof error === "object" && error !== null && "stderr" in error
+        ? (error as { stderr?: string | Buffer }).stderr
+        : undefined
+    const stderr = Buffer.isBuffer(stderrValue) ? stderrValue.toString("utf-8") : (stderrValue ?? "")
+    const noCrontab = status === 1 && (!stderr.trim() || /no crontab/i.test(stderr))
+    if (noCrontab) return ""
+    throw error
+  }
+}
+
+function writeUserCrontab(content: string): void {
+  const normalized = content.trim()
+  const input = normalized ? `${normalized}\n` : ""
+  execFileSync("crontab", ["-"], { input })
+}
+
+function stripManagedCronBlocks(content: string, blockIds: Set<string>): { content: string; removed: number } {
+  const lines = content ? content.split(/\r?\n/) : []
+  const retained: string[] = []
+  const prefix = `# BEGIN ${CRON_MANAGED_PREFIX} `
+  const endPrefix = `# END ${CRON_MANAGED_PREFIX} `
+  let removed = 0
+
+  for (let index = 0; index < lines.length; ) {
+    const line = lines[index]
+    if (!line.startsWith(prefix)) {
+      retained.push(line)
+      index += 1
+      continue
+    }
+
+    const id = line.slice(prefix.length).trim()
+    let endIndex = lines.length - 1
+    for (let probe = index + 1; probe < lines.length; probe += 1) {
+      if (lines[probe] === `${endPrefix}${id}`) {
+        endIndex = probe
+        break
+      }
+    }
+
+    if (blockIds.has(id)) {
+      removed += 1
+    } else {
+      for (let keep = index; keep <= endIndex; keep += 1) {
+        retained.push(lines[keep])
+      }
+    }
+
+    index = endIndex + 1
+  }
+
+  return {
+    content: retained.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd(),
+    removed,
+  }
+}
+
+function createCronEntry(job: Job): string {
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir())
+  const jobPath = jobFilePath(scopeId, job.slug)
+  const logFilePath = scopedLogPath(scopeId, job.slug)
+  const escapedSupervisor = shellEscapeDoubleQuoted(SUPERVISOR_PATH)
+  const escapedJobPath = shellEscapeDoubleQuoted(jobPath)
+  const escapedLogPath = shellEscapeDoubleQuoted(logFilePath)
+  const escapedPath = shellEscapeDoubleQuoted(getEnhancedPath())
+
+  return `${job.schedule} PATH="${escapedPath}" /usr/bin/perl "${escapedSupervisor}" "${escapedJobPath}" >> "${escapedLogPath}" 2>&1`
+}
+
+function installCronJob(job: Job): void {
+  if (!isCronAvailable()) {
+    throw new Error("cron backend is unavailable: `crontab` command not found.")
+  }
+
+  ensureDir(LOGS_DIR)
+  const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir())
+  ensureDir(scopeLogsDir(scopeId))
+  ensureSupervisorScript()
+
+  const blockId = cronBlockId(job)
+  const current = readUserCrontab()
+  const stripped = stripManagedCronBlocks(current, new Set([blockId, cronLegacyBlockId(job)]))
+  const block = [cronBlockStart(blockId), createCronEntry(job), cronBlockEnd(blockId)].join("\n")
+  const next = [stripped.content.trim(), block].filter(Boolean).join("\n\n")
+  writeUserCrontab(next)
+}
+
+function uninstallCronJob(job: Job): void {
+  if (!isCronAvailable()) return
+
+  const current = readUserCrontab()
+  const stripped = stripManagedCronBlocks(current, new Set([cronBlockId(job), cronLegacyBlockId(job)]))
+  if (stripped.removed === 0) return
+  writeUserCrontab(stripped.content)
+}
+
+function resolveSchedulerBackend(): SchedulerBackend {
+  if (IS_MAC) return "launchd"
+  if (IS_WINDOWS) return "schtasks"
+  if (isSystemdUserAvailable()) return "systemd"
+  if (isCronAvailable()) return "cron"
+
+  if (IS_LINUX) {
+    throw new Error(
+      "No supported scheduler backend found: systemd --user is unavailable and `crontab` is not installed."
+    )
+  }
+
+  throw new Error(
+    `Unsupported platform: ${platform()}. Supported platforms: macOS (launchd), Linux (systemd or cron), Windows, and POSIX systems with cron.`
+  )
+}
+
+function installJob(job: Job): SchedulerBackend {
+  const backend = resolveSchedulerBackend()
+  if (backend === "launchd") {
     installLaunchdJob(job)
-  } else if (IS_LINUX) {
-    installSystemdJob(job)
-  } else if (IS_WINDOWS) {
+  } else if (backend === "systemd") {
+    try {
+      installSystemdJob(job)
+    } catch (error) {
+      if (!isCronAvailable()) {
+        throw error
+      }
+      installCronJob(job)
+      return "cron"
+    }
+  } else if (backend === "schtasks") {
     installWindowsJob(job)
   } else {
-    throw new Error(`Unsupported platform: ${platform()}. Supported platforms: macOS, Linux, and Windows.`)
+    installCronJob(job)
   }
+  return backend
 }
 
 function uninstallJob(job: Job): void {
   if (IS_MAC) {
     uninstallLaunchdJob(job)
-  } else if (IS_LINUX) {
-    uninstallSystemdJob(job)
-  } else if (IS_WINDOWS) {
-    uninstallWindowsJob(job)
+    return
   }
+
+  if (IS_WINDOWS) {
+    uninstallWindowsJob(job)
+    return
+  }
+
+  if (IS_LINUX) {
+    uninstallSystemdJob(job)
+    uninstallCronJob(job)
+    return
+  }
+
+  uninstallCronJob(job)
 }
 
 // === JOB STORAGE ===
@@ -2343,7 +2539,7 @@ export const SchedulerPlugin: Plugin = async () => {
     tool: {
        schedule_job: tool({
            description:
-            "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac), systemd (Linux), or Windows Task Scheduler.",
+            "Schedule a recurring job to run an opencode prompt. Uses launchd (Mac), systemd (Linux), Windows Task Scheduler, or cron fallback when needed.",
           args: {
            name: tool.schema.string().describe("A short name for the job (e.g. 'standing desk search')"),
            schedule: tool.schema
@@ -2488,12 +2684,14 @@ export const SchedulerPlugin: Plugin = async () => {
 
            try {
              saveJob(job)
-             installJob(job)
+             const backend = installJob(job)
 
-             const platformName = IS_MAC ? "launchd" : IS_LINUX ? "systemd" : IS_WINDOWS ? "schtasks" : "unknown"
-             const reliabilityLine = IS_WINDOWS
+             const platformName = backend
+             const reliabilityLine = backend === "schtasks"
                ? "Windows note: scheduled runs use Task Scheduler directly. For advanced reliability guarantees, prefer simple cron schedules or split complex jobs."
-               : "The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes."
+               : backend === "cron"
+                 ? "Cron note: missed runs during sleep are not replayed. For catch-up behavior, use launchd or systemd when available."
+                 : "The job will run at the scheduled time. If your computer was asleep, it will catch up when it wakes."
              const primaryLine = run.command
                ? `Command: ${run.command}${run.arguments ? ` ${run.arguments}` : ""}`
                : `Prompt: ${(run.prompt ?? "").slice(0, 100)}${(run.prompt ?? "").length > 100 ? "..." : ""}`


### PR DESCRIPTION
## Summary
- add backend selection so macOS uses launchd, Windows uses Task Scheduler, Linux prefers `systemd --user`, and cron is used when native backends are unavailable
- add managed `crontab` install/uninstall support (scoped block markers) and fall back to cron if Linux systemd installation fails
- update scheduler messaging/docs to reflect cron fallback behavior and its missed-run catch-up limitation

Fixes #6