### PR TITLE
Fix invalid Systemd OnCalendar syntax (Issue #3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -838,7 +838,13 @@ function cronToSystemdCalendars(cron: string): string[] {
         for (const domValue of domValues) {
           for (const monthValue of months) {
             for (const dowValue of dowValues) {
-              calendars.push(`${dowValue} *-${monthValue}-${domValue} ${hourValue}:${minuteValue}:00`)
+              const datePart = `*-${monthValue}-${domValue}`
+              const timePart = `${hourValue}:${minuteValue}:00`
+              const calendar =
+                dowValue === "*"
+                  ? `${datePart} ${timePart}`
+                  : `${dowValue} ${datePart} ${timePart}`
+              calendars.push(calendar)
             }
           }
         }


### PR DESCRIPTION
## Summary
This PR fixes an issue where the `OnCalendar` syntax for systemd timers was generated incorrectly when the weekday was not specified (represented by `*`).

### Changes
- Updated `cronToSystemdCalendars` in `src/index.ts` to conditionally include the weekday in the `OnCalendar` string.
- According to `systemd.time(7)`, the weekday should be omitted if it is not specifically required, as systemd does not accept `*` as a valid weekday specifier in this context.

### Verification
- Verified that `0 9 * * *` (daily at 09:00) now correctly generates `OnCalendar=*-*-* 09:00:00` (previously `* *-*-* 09:00:00`).
- Verified that `30 8 * * 1` (Mondays at 08:30) correctly generates `OnCalendar=Mon *-*-* 08:30:00`.
- Validated the new syntax using `systemd-analyze calendar`.
- Confirmed that the project builds successfully with `bun run build`.

Fixes https://github.com/different-ai/opencode-scheduler/issues/3