### PR TITLE
feat: add V1 slash commands (list, get, logs, delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Schedule a job every 6 hours to check if my website is up and alert me on Slack 
 | Delete | `Delete the standing-desk job` |
 | Global cleanup (dry run) | `Run scheduler global cleanup` |
 
+## Slash Commands
+
+Type `/scheduler-` in OpenCode to see autocomplete suggestions. These commands invoke the corresponding tools directly.
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/scheduler-list` | 列出当前 scope 或全部 scope 的任务 | `/scheduler-list allScopes=true` |
+| `/scheduler-get` | 查看某个任务的详情 | `/scheduler-get standing-desk` |
+| `/scheduler-logs` | 查看某个任务的日志 | `/scheduler-logs standing-desk` |
+| `/scheduler-delete` | 删除某个任务（危险操作） | `/scheduler-delete standing-desk` |
+
 ## How It Works
 
 1. You describe what you want scheduled in natural language

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Type `/scheduler-` in OpenCode to see autocomplete suggestions. These commands i
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `/scheduler-list` | 列出当前 scope 或全部 scope 的任务 | `/scheduler-list allScopes=true` |
-| `/scheduler-get` | 查看某个任务的详情 | `/scheduler-get standing-desk` |
-| `/scheduler-logs` | 查看某个任务的日志 | `/scheduler-logs standing-desk` |
-| `/scheduler-delete` | 删除某个任务（危险操作） | `/scheduler-delete standing-desk` |
+| `/scheduler-list` | List jobs in current scope or all scopes | `/scheduler-list allScopes=true` |
+| `/scheduler-get` | Show details for a specific job | `/scheduler-get standing-desk` |
+| `/scheduler-logs` | Show recent logs for a job | `/scheduler-logs standing-desk` |
+| `/scheduler-delete` | Delete a job (destructive operation) | `/scheduler-delete standing-desk` |
 
 ## How It Works
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "test": "bun test",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [
@@ -49,7 +49,8 @@
   },
   "devDependencies": {
     "bun-types": "latest",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.0"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,7 +1,71 @@
 import { describe, test, expect } from "bun:test"
+import { schedulerCommands, applySchedulerCommands } from "./commands"
 
-describe("commands", () => {
-  test("placeholder", () => {
-    expect(true).toBe(true)
+describe("schedulerCommands", () => {
+  test("has exactly 4 command keys", () => {
+    const keys = Object.keys(schedulerCommands)
+    expect(keys).toHaveLength(4)
+    expect(keys.sort()).toEqual(
+      ["scheduler-delete", "scheduler-get", "scheduler-list", "scheduler-logs"].sort()
+    )
+  })
+
+  test("every command has a non-empty template string", () => {
+    for (const [name, cmd] of Object.entries(schedulerCommands)) {
+      expect(typeof cmd.template).toBe("string")
+      expect(cmd.template.length).toBeGreaterThan(0)
+    }
+  })
+
+  test("every command has a non-empty description string", () => {
+    for (const [name, cmd] of Object.entries(schedulerCommands)) {
+      expect(typeof cmd.description).toBe("string")
+      expect(cmd.description!.length).toBeGreaterThan(0)
+    }
+  })
+
+  test("scheduler-delete template contains 'confirm' for safety", () => {
+    expect(schedulerCommands["scheduler-delete"].template).toContain("confirm")
+  })
+
+  test("scheduler-get template contains $ARGUMENTS placeholder", () => {
+    expect(schedulerCommands["scheduler-get"].template).toContain("$ARGUMENTS")
+  })
+
+  test("scheduler-logs template contains $ARGUMENTS placeholder", () => {
+    expect(schedulerCommands["scheduler-logs"].template).toContain("$ARGUMENTS")
+  })
+
+  test("scheduler-delete template contains $ARGUMENTS placeholder", () => {
+    expect(schedulerCommands["scheduler-delete"].template).toContain("$ARGUMENTS")
+  })
+})
+
+describe("applySchedulerCommands", () => {
+  test("mutates config.command to include all 4 commands", () => {
+    const config: { command?: Record<string, any> } = {}
+    applySchedulerCommands(config)
+
+    expect(config.command).toBeDefined()
+    const keys = Object.keys(config.command!)
+    expect(keys).toContain("scheduler-list")
+    expect(keys).toContain("scheduler-get")
+    expect(keys).toContain("scheduler-logs")
+    expect(keys).toContain("scheduler-delete")
+  })
+
+  test("preserves existing commands in config", () => {
+    const config: { command?: Record<string, any> } = {
+      command: {
+        "my-custom-cmd": { template: "do something", description: "custom" },
+      },
+    }
+    applySchedulerCommands(config)
+
+    expect(config.command!["my-custom-cmd"]).toEqual({
+      template: "do something",
+      description: "custom",
+    })
+    expect(config.command!["scheduler-list"]).toBeDefined()
   })
 })

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test"
+import { describe, test, expect } from "vitest"
 import { schedulerCommands, applySchedulerCommands } from "./commands"
 
 describe("schedulerCommands", () => {
@@ -10,7 +10,7 @@ describe("schedulerCommands", () => {
     )
   })
 
-  test("every command has a non-empty template string", () => {
+  test("every command has a non-wempty template string", () => {
     for (const [name, cmd] of Object.entries(schedulerCommands)) {
       expect(typeof cmd.template).toBe("string")
       expect(cmd.template.length).toBeGreaterThan(0)

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,0 +1,7 @@
+import { describe, test, expect } from "bun:test"
+
+describe("commands", () => {
+  test("placeholder", () => {
+    expect(true).toBe(true)
+  })
+})

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,22 +4,22 @@ export const schedulerCommands: Record<
 > = {
   "scheduler-list": {
     template: "Use the list_jobs tool to show all scheduled jobs. $ARGUMENTS",
-    description: "列出当前 scope 或全部 scope 的任务",
+    description: "List jobs in current scope or all scopes",
   },
   "scheduler-get": {
     template:
       "Use the get_job tool to show details for the job named: $ARGUMENTS",
-    description: "查看某个任务的详情",
+    description: "Show details for a specific job",
   },
   "scheduler-logs": {
     template:
       "Use the job_logs tool to show recent logs for the job named: $ARGUMENTS",
-    description: "查看某个任务的日志",
+    description: "Show recent logs for a job",
   },
   "scheduler-delete": {
     template:
       "Use the delete_job tool to delete the job named: $ARGUMENTS. IMPORTANT: You must confirm the deletion with the user before proceeding.",
-    description: "删除某个任务（危险操作）",
+    description: "Delete a job (destructive operation)",
   },
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,31 @@
+export const schedulerCommands: Record<
+  string,
+  { template: string; description?: string }
+> = {
+  "scheduler-list": {
+    template: "Use the list_jobs tool to show all scheduled jobs. $ARGUMENTS",
+    description: "列出当前 scope 或全部 scope 的任务",
+  },
+  "scheduler-get": {
+    template:
+      "Use the get_job tool to show details for the job named: $ARGUMENTS",
+    description: "查看某个任务的详情",
+  },
+  "scheduler-logs": {
+    template:
+      "Use the job_logs tool to show recent logs for the job named: $ARGUMENTS",
+    description: "查看某个任务的日志",
+  },
+  "scheduler-delete": {
+    template:
+      "Use the delete_job tool to delete the job named: $ARGUMENTS. IMPORTANT: You must confirm the deletion with the user before proceeding.",
+    description: "删除某个任务（危险操作）",
+  },
+}
+
+export function applySchedulerCommands(config: {
+  command?: Record<string, any>
+}): void {
+  config.command = config.command || {}
+  Object.assign(config.command, schedulerCommands)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { basename, dirname, join, resolve as resolvePath } from "path"
 import { homedir, platform } from "os"
 import { execFileSync, execSync, spawn, type ChildProcess } from "child_process"
 import { fileURLToPath } from "url"
+import { applySchedulerCommands } from "./commands"
 
 // Storage location - shared with other opencode tools
 const OPENCODE_CONFIG = join(homedir(), ".config", "opencode")
@@ -2536,6 +2537,9 @@ function getJobLogs(job: Job, options?: { tailLines?: number; maxChars?: number 
 
 export const SchedulerPlugin: Plugin = async () => {
   return {
+    async config(input) {
+      applySchedulerCommands(input)
+    },
     tool: {
        schedule_job: tool({
            description:


### PR DESCRIPTION
## Summary

Add 4 slash commands to the opencode-scheduler plugin, enabling users to interact with scheduled jobs directly via `/scheduler-*` commands instead of remembering tool names and argument formats.

## Why

Currently, users must rely on natural language prompts or know the exact tool names (`list_jobs`, `get_job`, etc.) to manage scheduled jobs. Slash commands provide a discoverable, autocomplete-friendly interface that reduces friction.

## Commands

| Command | Description | Existing Tool |
|---------|-------------|---------------|
| `/scheduler-list` | List all scheduled jobs | `list_jobs` |
| `/scheduler-get` | Get details of a specific job by name | `get_job` |
| `/scheduler-logs` | View execution logs for a job | `job_logs` |
| `/scheduler-delete` | Delete a job (with confirmation) | `delete_job` |

## How It Works

- Commands are registered via the plugin's `config` hook, which injects command templates into `Config.command` at plugin load time.
- Each command is a **prompt template** containing `$ARGUMENTS` placeholder — OpenCode replaces this with user input and sends it to the LLM, which then calls the corresponding existing tool.
- No changes to existing tool implementations. Commands are a UI layer on top of existing functionality.

## Scope (V1)

This is intentionally scoped to **read-only + delete** operations only. Commands like `schedule`, `run`, `update`, and `cleanup` are deferred to a future version.

## Backward Compatibility

- **No breaking changes.** Existing natural language prompts and direct tool calls continue to work exactly as before.
- The `config` hook preserves any pre-existing commands via object spread.

## Testing

- **9 tests, 29 assertions** using vitest
- Coverage: command keys, template content, descriptions, safety confirmation (`delete`), `$ARGUMENTS` placeholders, config mutation, existing command preservation

## Files Changed

| File | Change |
|------|--------|
| `src/commands.ts` | **New** — 4 command templates + `applySchedulerCommands()` |
| `src/commands.test.ts` | **New** — 9 tests with vitest |
| `src/index.ts` | **Modified** — Added import (line 21) + 3 lines in config hook (line 2540-2542) |
| `README.md` | **Modified** — Added slash commands documentation section |
| `package.json` | **Modified** — Added vitest devDependency + test script |