### PR TITLE
fix: add scope options to job tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Scopes are derived from the job's `workdir` (normalized absolute path). This iso
 
 - `list_jobs` defaults to the **current scope** (your current working directory).
 - Use `allScopes: true` to list jobs across all scopes.
+- Job-specific tools (`get_job`, `update_job`, `delete_job`, `run_job`, `job_logs`) also accept `allScopes`, `scopeRoot`, and `includeLegacy` when you need to operate on a job outside the current scope.
 - Use `includeLegacy: true` to include pre-`v1.2.0` jobs stored in `~/.config/opencode/jobs`.
 
 ### Attach URL (optional)

--- a/dist/index.js
+++ b/dist/index.js
@@ -14025,6 +14025,13 @@ function findJobByName(name, options) {
   }
   return job;
 }
+function findJobOptionsFromArgs(args) {
+  return {
+    allScopes: args.allScopes,
+    includeLegacy: args.includeLegacy,
+    scopeId: args.scopeRoot ? deriveScopeId(normalizeWorkdirPath(args.scopeRoot)) : undefined
+  };
+}
 function updateJobRecord(job, updates) {
   const scopeId = job.scopeId || deriveScopeId(job.workdir || homedir());
   const latest = loadScopedJob(scopeId, job.slug) || job;
@@ -14637,11 +14644,14 @@ ${content.trim()}
         description: "Get details for a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema.string().optional().describe("Optional: scope root directory (defaults to current directory)."),
           format: tool.schema.string().optional().describe("Optional: output format ('text' or 'json').")
         },
         async execute(args) {
           const format = normalizeFormat(args.format);
-          const job = findJobByName(args.name);
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args));
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`);
           }
@@ -14652,6 +14662,9 @@ ${content.trim()}
         description: "Update a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema.string().optional().describe("Optional: scope root directory (defaults to current directory)."),
           schedule: tool.schema.string().optional().describe("Updated cron expression"),
           prompt: tool.schema.string().optional().describe("Updated prompt (legacy; prefer command/arguments/etc)"),
           command: tool.schema.string().optional().describe("Updated opencode command (maps to --command)"),
@@ -14673,7 +14686,7 @@ ${content.trim()}
         },
         async execute(args) {
           const format = normalizeFormat(args.format);
-          const job = findJobByName(args.name);
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args));
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`);
           }
@@ -14799,11 +14812,14 @@ ${content.trim()}
         description: "Delete a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug to delete"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema.string().optional().describe("Optional: scope root directory (defaults to current directory)."),
           format: tool.schema.string().optional().describe("Optional: output format ('text' or 'json').")
         },
         async execute(args) {
           const format = normalizeFormat(args.format);
-          const job = findJobByName(args.name);
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args));
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`);
           }
@@ -14846,6 +14862,9 @@ ${content.trim()}
         description: "Run a scheduled job immediately",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema.string().optional().describe("Optional: scope root directory (defaults to current directory)."),
           prompt: tool.schema.string().optional().describe("Override prompt for this run"),
           command: tool.schema.string().optional().describe("Override command for this run"),
           arguments: tool.schema.string().optional().describe("Override arguments for command mode"),
@@ -14864,7 +14883,7 @@ ${content.trim()}
         },
         async execute(args) {
           const format = normalizeFormat(args.format);
-          const job = findJobByName(args.name);
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args));
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found. Use list_jobs to see available jobs.`);
           }
@@ -14939,12 +14958,15 @@ Logs: ${runResult.logPath}${attachHint}${logSection}`, {
         description: "View the latest logs from a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema.string().optional().describe("Optional: scope root directory (defaults to current directory)."),
           lines: tool.schema.number().optional().describe("Number of lines from the end of the log (default 200)."),
           format: tool.schema.string().optional().describe("Optional: output format ('text' or 'json').")
         },
         async execute(args) {
           const format = normalizeFormat(args.format);
-          const job = findJobByName(args.name);
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args));
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`);
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2098,9 +2098,11 @@ function normalizeJob(raw: unknown): Job | null {
   return sanitizeJob(job)
 }
 
+type FindJobOptions = { scopeId?: string; allScopes?: boolean; includeLegacy?: boolean }
+
 function findJobByName(
   name: string,
-  options?: { scopeId?: string; allScopes?: boolean; includeLegacy?: boolean }
+  options?: FindJobOptions
 ): Job | null {
   const scopeId = options?.scopeId ?? currentScopeId()
   const slug = slugify(name)
@@ -2147,6 +2149,14 @@ function findJobByName(
   }
 
   return job
+}
+
+function findJobOptionsFromArgs(args: { allScopes?: boolean; includeLegacy?: boolean; scopeRoot?: string }): FindJobOptions {
+  return {
+    allScopes: args.allScopes,
+    includeLegacy: args.includeLegacy,
+    scopeId: args.scopeRoot ? deriveScopeId(normalizeWorkdirPath(args.scopeRoot)) : undefined,
+  }
 }
 
 function updateJobRecord(job: Job, updates: Partial<Job>): Job {
@@ -2909,11 +2919,17 @@ Commands:
         description: "Get details for a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema
+            .string()
+            .optional()
+            .describe("Optional: scope root directory (defaults to current directory)."),
           format: tool.schema.string().optional().describe("Optional: output format ('text' or 'json')."),
         },
         async execute(args) {
           const format = normalizeFormat(args.format)
-          const job = findJobByName(args.name)
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args))
 
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`)
@@ -2927,6 +2943,12 @@ Commands:
         description: "Update a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema
+            .string()
+            .optional()
+            .describe("Optional: scope root directory (defaults to current directory)."),
           schedule: tool.schema.string().optional().describe("Updated cron expression"),
 
           // Legacy prompt field
@@ -2959,7 +2981,7 @@ Commands:
         },
         async execute(args) {
           const format = normalizeFormat(args.format)
-          const job = findJobByName(args.name)
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args))
 
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`)
@@ -3111,11 +3133,17 @@ Commands:
         description: "Delete a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug to delete"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema
+            .string()
+            .optional()
+            .describe("Optional: scope root directory (defaults to current directory)."),
           format: tool.schema.string().optional().describe("Optional: output format ('text' or 'json')."),
         },
         async execute(args) {
           const format = normalizeFormat(args.format)
-          const job = findJobByName(args.name)
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args))
 
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`)
@@ -3174,6 +3202,12 @@ Commands:
         description: "Run a scheduled job immediately",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema
+            .string()
+            .optional()
+            .describe("Optional: scope root directory (defaults to current directory)."),
           // Optional overrides for a one-off run
           prompt: tool.schema.string().optional().describe("Override prompt for this run"),
           command: tool.schema.string().optional().describe("Override command for this run"),
@@ -3193,7 +3227,7 @@ Commands:
         },
         async execute(args) {
           const format = normalizeFormat(args.format)
-          const job = findJobByName(args.name)
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args))
 
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found. Use list_jobs to see available jobs.`)
@@ -3278,6 +3312,12 @@ Commands:
         description: "View the latest logs from a scheduled job",
         args: {
           name: tool.schema.string().describe("The job name or slug"),
+          allScopes: tool.schema.boolean().optional().describe("Search across all scopes."),
+          includeLegacy: tool.schema.boolean().optional().describe("Include legacy jobs from ~/.config/opencode/jobs"),
+          scopeRoot: tool.schema
+            .string()
+            .optional()
+            .describe("Optional: scope root directory (defaults to current directory)."),
           lines: tool.schema
             .number()
             .optional()
@@ -3286,7 +3326,7 @@ Commands:
         },
         async execute(args) {
           const format = normalizeFormat(args.format)
-          const job = findJobByName(args.name)
+          const job = findJobByName(args.name, findJobOptionsFromArgs(args))
 
           if (!job) {
             return errorResult(format, `Job "${args.name}" not found.`)


### PR DESCRIPTION
## Summary
- Add `allScopes`, `scopeRoot`, and `includeLegacy` options to job-specific tools.
- Wire `get_job`, `update_job`, `delete_job`, `run_job`, and `job_logs` through the existing scoped lookup options.
- Document using scope options for job-specific tools.

## Why
`list_jobs` already supports `allScopes`, `scopeRoot`, and `includeLegacy`, but after discovering a job outside the current scope there was no equivalent way to retrieve, run, update, delete, or inspect logs for that job by name.

This keeps current default scoping behavior unchanged while adding explicit parity with `list_jobs`.

## Test
- `npm run typecheck`
- `npm run build`